### PR TITLE
Fix table design

### DIFF
--- a/webview/assets/stylesheets/stylesheet.css
+++ b/webview/assets/stylesheets/stylesheet.css
@@ -92,12 +92,7 @@ table{
 }
 
 tr:nth-child(2n+1){
-    background: red;
-    border: 1px solid red;
-}
-
-tr:nth-child(2n+1){
-    background: #2f2e2e;
+    background: #d5d5d5;
 }
 
 tr{


### PR DESCRIPTION
Changes the background color to `#d5d5d5`, so it fixes #6
And removes that red(??!) background and border color. The background color has been overwritten anyway and the border color was for some reason never visible, as far as I see.

![fix](https://user-images.githubusercontent.com/11966684/76558077-f2d5e000-649c-11ea-8e5e-42af2169e438.png)

(only tested with in-place website editing)